### PR TITLE
Feature/support large list merge (do not merge)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -402,7 +402,7 @@ install:
 - |
   if [[ "${TRAVIS_BUILD_STAGE_NAME}" == "Lint" ]]
   then
-    DOXYGEN_URL="ftp://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.14.src.tar.gz"
+    DOXYGEN_URL="http://www.doxygen.nl/files/doxygen-1.8.14.src.tar.gz"
     mkdir -p "${DEPS_PATH}/doxygen"
     travis_retry curl -L "${DOXYGEN_URL}" | tar --strip-components=1 -xz -C "${DEPS_PATH}/doxygen" || exit $?
     cmake -H"${DEPS_PATH}/doxygen" -B"${DEPS_PATH}/doxygen/build" || exit $?

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ configuration:
 install:
   - git -C "%APPVEYOR_BUILD_FOLDER%" submodule update --init --recursive
 
-  - if "%CHECK_DOC%" equ "true" (choco install doxygen.portable)
+  - if "%CHECK_DOC%" equ "true" (choco install doxygen.install)
 
 before_build:
   - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%

--- a/include/metal/list/sort.hpp
+++ b/include/metal/list/sort.hpp
@@ -49,6 +49,7 @@ namespace metal {
 }
 
 #include "../lambda/lambda.hpp"
+#include "../list/join.hpp"
 #include "../list/list.hpp"
 #include "../list/range.hpp"
 #include "../number/if.hpp"
@@ -57,6 +58,7 @@ namespace metal {
 namespace metal {
     /// \cond
     namespace detail {
+
         template<typename>
         struct cons {};
 
@@ -75,35 +77,116 @@ namespace metal {
         template<
             typename, typename, typename, template<typename...> class,
             typename = true_>
-        struct _merge {};
+        struct _partial_merge {};
 
         template<
             typename x, typename y, typename... zs,
             template<typename...> class e>
-        struct _merge<
+        struct _partial_merge<
             x, y, list<zs...>, e, if_<call<e, head<y>, head<x>>, true_, false_>>
-            : _merge<x, tail<y>, list<zs..., head<y>>, e> {};
+            : _partial_merge<x, tail<y>, list<zs..., head<y>>, e> {};
 
         template<
             typename x, typename y, typename... zs,
             template<typename...> class e>
-        struct _merge<
+        struct _partial_merge<
             x, y, list<zs...>, e, if_<call<e, head<y>, head<x>>, false_, true_>>
-            : _merge<tail<x>, y, list<zs..., head<x>>, e> {};
+            : _partial_merge<tail<x>, y, list<zs..., head<x>>, e> {};
 
         template<typename... xs, typename... zs, template<typename...> class e>
-        struct _merge<list<xs...>, list<>, list<zs...>, e> {
-            using type = list<zs..., xs...>;
+        struct _partial_merge<list<xs...>, list<>, list<zs...>, e> {
+            using type = list<zs...>;
+            using l1_carry = list<xs...>;
+            using l2_carry = list<>;
         };
 
         template<typename... ys, typename... zs, template<typename...> class e>
-        struct _merge<list<>, list<ys...>, list<zs...>, e> {
-            using type = list<zs..., ys...>;
+        struct _partial_merge<list<>, list<ys...>, list<zs...>, e> {
+            using type = list<zs...>;
+            using l1_carry = list<>;
+            using l2_carry = list<ys...>;
         };
 
         template<typename z, template<typename...> class e>
-        struct _merge<list<>, list<>, z, e> {
+        struct _partial_merge<list<>, list<>, z, e> {
             using type = z;
+            using l1_carry = list<>;
+            using l2_carry = list<>;
+        };
+
+        template<class, class, typename = true_>
+        struct _large_partial_merge {};
+
+        template<class... e1s, class... e2s>
+        struct _large_partial_merge<
+            list<e1s...>, list<e2s...>,
+            number<(
+                (sizeof...(e1s) >= 2) && (sizeof...(e2s) >= 2)
+                && (sizeof...(e1s) + sizeof...(e2s)) > 512)>> {
+            using l1 = list<e1s...>;
+            using l2 = list<e2s...>;
+
+            using l1_half1 = range<l1, number<0>, number<sizeof...(e1s) / 2>>;
+            using l2_half1 = range<l2, number<0>, number<sizeof...(e2s) / 2>>;
+
+            using l1_half2 =
+                range<l1, number<sizeof...(e1s) / 2>, number<sizeof...(e1s)>>;
+            using l2_half2 =
+                range<l2, number<sizeof...(e2s) / 2>, number<sizeof...(e2s)>>;
+
+            template<template<class...> class cmp>
+            using sub_merge1 = _large_partial_merge<l1_half1, l2_half1>;
+
+            template<template<class...> class cmp>
+            using l1_half2_with_carry = join<
+                typename sub_merge1<cmp>::template l1_carry<cmp>, l1_half2>;
+
+            template<template<class...> class cmp>
+            using l2_half2_with_carry = join<
+                typename sub_merge1<cmp>::template l2_carry<cmp>, l2_half2>;
+
+            template<template<class...> class cmp>
+            using sub_merge2 = _large_partial_merge<
+                l1_half2_with_carry<cmp>, l2_half2_with_carry<cmp>>;
+
+            template<template<class...> class cmp>
+            using type = join<
+                typename sub_merge1<cmp>::template type<cmp>,
+                typename sub_merge2<cmp>::template type<cmp>>;
+
+            template<template<class...> class cmp>
+            using l1_carry = typename sub_merge2<cmp>::template l1_carry<cmp>;
+
+            template<template<class...> class cmp>
+            using l2_carry = typename sub_merge2<cmp>::template l2_carry<cmp>;
+        };
+
+        template<class... e1s, class... e2s>
+        struct _large_partial_merge<
+            list<e1s...>, list<e2s...>,
+            number<!(
+                (sizeof...(e1s) >= 2) && (sizeof...(e2s) >= 2)
+                && (sizeof...(e1s) + sizeof...(e2s)) > 512)>> {
+            template<template<class...> class cmp>
+            using type = typename _partial_merge<
+                list<e1s...>, list<e2s...>, list<>, cmp>::type;
+
+            template<template<class...> class cmp>
+            using l1_carry = typename _partial_merge<
+                list<e1s...>, list<e2s...>, list<>, cmp>::l1_carry;
+
+            template<template<class...> class cmp>
+            using l2_carry = typename _partial_merge<
+                list<e1s...>, list<e2s...>, list<>, cmp>::l2_carry;
+        };
+
+        template<class l1, class l2, template<class...> class e>
+        struct _merge {
+            using sub_merge = _large_partial_merge<l1, l2>;
+            using type = join<
+                forward<sub_merge::template type, e>,
+                forward<sub_merge::template l1_carry, e>,
+                forward<sub_merge::template l2_carry, e>>;
         };
 
         template<typename seq>
@@ -120,7 +203,7 @@ namespace metal {
             using type = typename _merge<
                 forward<_sort_impl<range<seq, beg, mid>>::template type, expr>,
                 forward<_sort_impl<range<seq, mid, end>>::template type, expr>,
-                list<>, expr>::type;
+                expr>::type;
         };
 
         template<typename x, typename y>


### PR DESCRIPTION
This PR is intended to share the work I have done related to the discussion in #84 . I'm working both in the suggestion from https://github.com/brunocodutra/metal/issues/84#issuecomment-458742205 and with the idea of creating an algorithm for large lists that fallback on the current algorithm (but adapted to be partial merge) when the lists are smaller.

Upon my testing this version does not impose significant perfomance drawbacks, while allowing the `sort` algorithm to work to list sizes going up to 5000 (which is what I tested).

I'm also opening the PR to have the CI to run this in different compilers.
