### PR TITLE
implement `min_element` (benchmark linked in description)

### DIFF
--- a/example/src/list.cpp
+++ b/example/src/list.cpp
@@ -677,4 +677,44 @@ IS_SAME(
 );
 /// [accumulate]
 )
+
+HIDE(
+/// [min_element]
+using nums = metal::numbers<4, 42, 17, -7, 0>;
+
+using comp_lt = metal::lambda<metal::less>;
+IS_SAME(metal::min_element<nums, comp_lt>, metal::number<-7>);
+
+using comp_gt = metal::lambda<metal::greater>;
+IS_SAME(metal::min_element<nums, comp_gt>, metal::number<42>);
+
+template<class a, class b, class>
+using bad_comp_three_args = metal::less<a, b>;
+
+static_assert(
+  !metal::is_invocable<
+  metal::lambda<metal::min_element>,
+  nums,
+  metal::lambda<bad_comp_three_args>
+  >{}, "");
+
+static_assert(
+  !metal::is_invocable<
+  metal::lambda<metal::min_element>,
+  metal::list<>,
+  metal::lambda<metal::less>
+  >{}, "");
+
+using vals = metal::list<const char[3], char[1], char[1], char[3], const char[1]>;
+
+template<typename x, typename y>
+using smaller = metal::number<(sizeof(x) < sizeof(y))>;
+IS_SAME(metal::min_element<vals, metal::lambda<smaller>>, char[1]);
+
+template<typename x, typename y>
+using larger = metal::number<(sizeof(x) > sizeof(y))>;
+IS_SAME(metal::min_element<vals, metal::lambda<larger>>, const char[3]);
+/// [min_element]
+)
+
 #endif

--- a/include/metal/list.hpp
+++ b/include/metal/list.hpp
@@ -28,6 +28,7 @@
 #include "list/iota.hpp"
 #include "list/join.hpp"
 #include "list/list.hpp"
+#include "list/min_element.hpp"
 #include "list/none_of.hpp"
 #include "list/partition.hpp"
 #include "list/powerset.hpp"

--- a/include/metal/list/min_element.hpp
+++ b/include/metal/list/min_element.hpp
@@ -1,0 +1,59 @@
+#ifndef METAL_LIST_MIN_ELEMENT_HPP
+#define METAL_LIST_MIN_ELEMENT_HPP
+
+#include "../config.hpp"
+#include "../detail/sfinae.hpp"
+#include "../lambda/lambda.hpp"
+#include "../list/list.hpp"
+#include "../number/if.hpp"
+
+namespace metal {
+    namespace detail {
+
+        template<bool done = false>
+        struct _min_element_worker;
+
+        template<>
+        struct _min_element_worker<false> {
+            template<
+                template<class...> class comp, class v0, class v1,
+                class... tail>
+            using type = typename _min_element_worker<!sizeof...(
+                tail)>::template type<comp, if_<comp<v1, v0>, v1, v0>, tail...>;
+            // TODO: introduce the analogue of detail::call/detail::forward ???
+        };
+
+        template<>
+        struct _min_element_worker<true> {
+            template<template<class...> class comp, class v0>
+            using type = v0;
+        };
+
+        template<class seq>
+        struct _min_element_impl {};
+
+        template<class v0, class... tail>
+        struct _min_element_impl<list<v0, tail...>> {
+            template<template<class...> class comp>
+            using type = typename _min_element_worker<!sizeof...(
+                tail)>::template type<comp, v0, tail...>;
+            // TODO: introduce the analogue of detail::call/detail::forward ???
+        };
+
+        template<class lbd>
+        struct _min_element {};
+
+        template<template<class...> class comp>
+        struct _min_element<lambda<comp>> {
+            template<class seq>
+            using type = forward<_min_element_impl<seq>::template type, comp>;
+        };
+
+    } // detail
+
+    template<class seq, class lbd>
+    using min_element =
+        detail::call<detail::_min_element<lbd>::template type, seq>;
+} // metal
+
+#endif


### PR DESCRIPTION
See #73.

Performance of [Clang 8](https://ecrypa.github.io/metal-benchmark/min_element_clang8/) and [GCC 9](https://ecrypa.github.io/metal-benchmark/min_element_gcc9/) is similar (v5 refers to this version; [v4 is based on `metal::bind` and `metal::arg`](https://github.com/ecrypa/metal/tree/experiment/min-element-v4)).

I suspect that the most expensive operation in this version is the recursive call of `typename _min_element_worker<false>::template type`. The recursion processes one element per step (no fast-tracking), and each call uses O(N) template arguments. It should be more efficient to cut the list into smaller pieces, calculate the minima of the pieces, and then calculate the minima of the minima. I guess you know the tree-based lookup of `kvasir` as explained in [this blog post](http://odinthenerd.blogspot.com/2017/04/tree-based-lookup-why-kvasirmpl-is.html) from Odin Holmes?