### PR TITLE
MSVC workaround for default ordering (v2)

### DIFF
--- a/example/src/list.cpp
+++ b/example/src/list.cpp
@@ -537,6 +537,11 @@ IS_SAME(
     metal::sort<l, metal::lambda<not_bigger>>, // non-stable sorting
     metal::list<uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t>
 );
+
+IS_SAME(
+    metal::sort<metal::numbers<7, -8, -3, 2>>, // use default ordering relation
+    metal::sort<metal::numbers<7, -8, -3, 2>, metal::lambda<metal::less>>
+);
 /// [sort]
 )
 

--- a/include/metal/list/sort.hpp
+++ b/include/metal/list/sort.hpp
@@ -3,13 +3,15 @@
 
 #include "../config.hpp"
 #include "../detail/sfinae.hpp"
+#include "../lambda/lambda.hpp"
 #include "../list/list.hpp"
 #include "../number/if.hpp"
+#include "../number/less.hpp"
 
 namespace metal {
     /// \cond
     namespace detail {
-        template<class lbd>
+        template<class lbd = metal::lambda<metal::less>>
         struct _sort;
     }
     /// \endcond
@@ -19,7 +21,7 @@ namespace metal {
     /// ### Description
     /// Sorts the elements of a \list according to an ordering relation.
     ///
-    /// \tip{The sorting is [stable] if the ordering relation is [strict].}
+    /// \note{The sorting is [stable] if the ordering relation is [strict].}
     /// [stable]: https://en.wikipedia.org/wiki/Sorting_algorithm#Stability
     /// [strict]: https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
     ///
@@ -28,6 +30,8 @@ namespace metal {
     /// \code
     ///     using result = metal::sort<l, lbd>;
     /// \endcode
+    ///
+    /// \tip{`lbd` may be omitted, in which case it defaults to `metal::lambda<metal::less>`.}
     ///
     /// \pre: For any two \values `val_i` and `val_j` contained in `l`
     /// `metal::invoke<lbd, val_i, val_j>` returns a \number
@@ -46,9 +50,9 @@ namespace metal {
     ///
     /// ### See Also
     /// \see list, reverse, rotate
-    template<class seq, class lbd>
+    template<class seq, class... lbd>
     using sort = detail::call<
-        detail::_sort<lbd>::template type,
+        detail::_sort<lbd...>::template type,
         metal::if_<metal::is_list<seq>, seq>>;
 }
 

--- a/include/metal/list/sort.hpp
+++ b/include/metal/list/sort.hpp
@@ -11,8 +11,10 @@
 namespace metal {
     /// \cond
     namespace detail {
-        template<class lbd = metal::lambda<metal::less>>
+        template<class lbd>
         struct _sort;
+
+        using sort_default_lbd = metal::lambda<metal::less>;
     }
     /// \endcond
 
@@ -50,9 +52,9 @@ namespace metal {
     ///
     /// ### See Also
     /// \see list, reverse, rotate
-    template<class seq, class... lbd>
+    template<class seq, class lbd = detail::sort_default_lbd>
     using sort = detail::call<
-        detail::_sort<lbd...>::template type,
+        detail::_sort<lbd>::template type,
         metal::if_<metal::is_list<seq>, seq>>;
 }
 

--- a/test/unit/src/metal/list/sort.cpp
+++ b/test/unit/src/metal/list/sort.cpp
@@ -42,7 +42,6 @@
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, MAP(M), MAP(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, MAP(M), LAMBDA(N)>), (BOOL(N == 2 || M < 2))); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, MAP(M), LAMBDA(_)>), (BOOL(M < 2))); \
-    CHECK((metal::is_invocable<metal::lambda<metal::sort> COMMA(M) NUMBERS(M)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, metal::list<NUMBERS(M)>>), (TRUE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, metal::list<NUMBERS(M)>, VALUE(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, metal::list<NUMBERS(M)>, NUMBER(N)>), (FALSE)); \

--- a/test/unit/src/metal/list/sort.cpp
+++ b/test/unit/src/metal/list/sort.cpp
@@ -3,12 +3,14 @@
 #include "test.hpp"
 
 #define MATRIX(M, N) \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, VALUE(M)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, VALUE(M), VALUE(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, VALUE(M), NUMBER(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, VALUE(M), PAIR(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, VALUE(M), LIST(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, VALUE(M), MAP(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, VALUE(M), LAMBDA(N)>), (FALSE)); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, NUMBER(M)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, NUMBER(M), VALUE(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, NUMBER(M), NUMBER(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, NUMBER(M), PAIR(N)>), (FALSE)); \
@@ -16,6 +18,7 @@
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, NUMBER(M), MAP(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, NUMBER(M), LAMBDA(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, NUMBER(M), LAMBDA(_)>), (FALSE)); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, PAIR(M)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, PAIR(M), VALUE(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, PAIR(M), NUMBER(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, PAIR(M), PAIR(N)>), (FALSE)); \
@@ -23,6 +26,7 @@
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, PAIR(M), MAP(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, PAIR(M), LAMBDA(N)>), (BOOL(N == 2))); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, PAIR(M), LAMBDA(_)>), (FALSE)); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, LIST(M)>), (BOOL(M < 2))); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LIST(M), VALUE(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LIST(M), NUMBER(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LIST(M), PAIR(N)>), (FALSE)); \
@@ -30,6 +34,7 @@
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LIST(M), MAP(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LIST(M), LAMBDA(N)>), (BOOL(N == 2 || M < 2))); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LIST(M), LAMBDA(_)>), (BOOL(M < 2))); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, MAP(M)>), (BOOL(M < 2))); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, MAP(M), VALUE(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, MAP(M), NUMBER(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, MAP(M), PAIR(N)>), (FALSE)); \
@@ -37,6 +42,17 @@
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, MAP(M), MAP(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, MAP(M), LAMBDA(N)>), (BOOL(N == 2 || M < 2))); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, MAP(M), LAMBDA(_)>), (BOOL(M < 2))); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort> COMMA(M) NUMBERS(M)>), (FALSE)); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, metal::list<NUMBERS(M)>>), (TRUE)); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, metal::list<NUMBERS(M)>, VALUE(N)>), (FALSE)); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, metal::list<NUMBERS(M)>, NUMBER(N)>), (FALSE)); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, metal::list<NUMBERS(M)>, PAIR(N)>), (FALSE)); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, metal::list<NUMBERS(M)>, LIST(N)>), (FALSE)); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, metal::list<NUMBERS(M)>, MAP(N)>), (FALSE)); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, metal::list<NUMBERS(M)>, metal::list<NUMBERS(N)>>), (FALSE)); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, metal::list<NUMBERS(M)>, LAMBDA(N)>), (BOOL(N == 2 || M < 2))); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, metal::list<NUMBERS(M)>, LAMBDA(_)>), (BOOL(M < 2))); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, LAMBDA(M)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LAMBDA(M), VALUE(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LAMBDA(M), NUMBER(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LAMBDA(M), PAIR(N)>), (FALSE)); \
@@ -44,6 +60,7 @@
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LAMBDA(M), MAP(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LAMBDA(M), LAMBDA(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LAMBDA(M), LAMBDA(_)>), (FALSE)); \
+    CHECK((metal::is_invocable<metal::lambda<metal::sort>, LAMBDA(_)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LAMBDA(_), VALUE(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LAMBDA(_), NUMBER(N)>), (FALSE)); \
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LAMBDA(_), PAIR(N)>), (FALSE)); \
@@ -53,7 +70,9 @@
     CHECK((metal::is_invocable<metal::lambda<metal::sort>, LAMBDA(_), LAMBDA(_)>), (FALSE)); \
     CHECK((metal::sort<metal::list<NUMBERSX20(M)>, metal::lambda<metal::greater>>), (metal::list<RENUM(M, FWD, NUMBERX20)>)); \
     CHECK((metal::sort<metal::list<NUMBERSX20(M)>, metal::lambda<metal::less>>), (metal::list<NUMBERSX20(M)>)); \
+    CHECK((metal::sort<metal::list<NUMBERSX20(M)>>), (metal::list<NUMBERSX20(M)>)); \
     CHECK((metal::sort<metal::list<ENUM(INC(N), NUMBERS FIX(INC(M)))>, metal::lambda<metal::less>>), (metal::list<ENUM(INC(M), FWD, RENUM(INC(N), NUMBER NIL))>)); \
+    CHECK((metal::sort<metal::list<ENUM(INC(N), NUMBERS FIX(INC(M)))>>), (metal::list<ENUM(INC(M), FWD, RENUM(INC(N), NUMBER NIL))>)); \
 /**/
 
 GEN(MATRIX)


### PR DESCRIPTION
Maybe MSVC has troubles if default arguments contain `<` or `>` characters. Let us hope this passes.