### PR TITLE
Allow building metal without documentation, examples and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ include(cmake/Test.cmake)
 
 project(Metal CXX)
 
+option(METAL_BUILD_DOC "Whether to build the documentation" ON)
+option(METAL_BUILD_EXAMPLES "Whether to build the examples" ON)
+option(METAL_BUILD_TESTS "Whether to build the tests" ON)
+
 set(METAL_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include/")
 
 file(STRINGS "${METAL_INCLUDE_DIR}/metal/config/version.hpp"
@@ -31,6 +35,12 @@ set_target_properties(Metal PROPERTIES
 
 deploy_header_library(Metal)
 
-add_subdirectory(doc)
-add_subdirectory(example)
-add_subdirectory(test)
+if(METAL_BUILD_DOC)
+    add_subdirectory(doc)
+endif()
+if (METAL_BUILD_EXAMPLES)
+    add_subdirectory(example)
+endif()
+if(METAL_BUILD_TESTS)
+    add_subdirectory(test)
+endif()


### PR DESCRIPTION
Users including metal in their projects using CMake's ExternalProject_Add,
FetchContent or a git submodule with `add_subdirectory` might not want to
build the docs, examples or tests. In fact, they might not even have the
dependencies (doxygen for docs, boost for examples), which causes CMake to
print a warning even though it doesn't cause build failures.

For such users metal now provides options METAL_BUILD_DOC,
METAL_BUILD_TESTS and METAL_BUILD_EXAMPLES that are ON by default, but
can be turned off by consumers.